### PR TITLE
make SO_BROADCAST enabled

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -41,7 +41,7 @@ namespace bnr {
             return false;
         }
 
-        int y;
+        const int y = 1;
         setsockopt(sock, SOL_SOCKET, SO_BROADCAST, &y, sizeof(y));
         timeval tv = {};
         tv.tv_sec = 0;


### PR DESCRIPTION
I got "bnr::Query: sendto: : Permission denied" message when I use client.
Then I found that SO_BROADCAST of setsockopt is not enabled.