### PR TITLE
fix forgetting to close socket

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -21,6 +21,7 @@
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
+#include <unistd.h>
 #elif defined(__WIN32__)
 #error "Windows is not supported."
 #else  // ESP32
@@ -59,6 +60,7 @@ namespace bnr {
                    static_cast<const sockaddr *>(static_cast<const void *>(&addr)),
                    sizeof(addr)) < 0) {
             perror("bnr::Query: sendto: ");
+            close(sock);
             return false;
         }
 
@@ -72,11 +74,14 @@ namespace bnr {
                     continue;
                 } else {
                     perror("bnr::Query: recv: ");
+                    close(sock);
                     return false;
                 }
             }
             res.emplace_back(Response::FromDatagram(buf));
         }
+
+        close(sock);
         return !res.empty();
     }
 


### PR DESCRIPTION
On ESP32, after using bnr::lookup multiple times, I got the "bnr::Query: socket: : Too many open files in system" message.
Then I found sockets are not closed after using. So I fixed it.